### PR TITLE
Fixed Title display on showTitle = false error

### DIFF
--- a/dist/pptxgen.js
+++ b/dist/pptxgen.js
@@ -2401,6 +2401,10 @@ var PptxGenJS = function(){
 				});
 				strXml += '<c:autoTitleDeleted val="0"/>';
 			}
+			//NOTE: Add autoTitleDeleted tag in else to prevent default creation of chart title even when showTitle is set to false
+			else {
+				strXml += '<c:autoTitleDeleted val="1"/>';
+			}
 
 			strXml += '<c:plotArea>';
 			// IMPORTANT: Dont specify layout to enable auto-fit: PPT does a great job maximizing space with all 4 TRBL locations


### PR DESCRIPTION
In Microsoft PowerPoint 2007, even the absence of <title> tag in xml on setting showTitle=false is creating a title by default with a value of 'name' key of the JSON input. This can be fixed by setting <c:autoTitleDeleted val="1"/> tag when rel.opts.showTitle is false. 

This problem does not exist in the later versions of PowerPoint but is present in PowerPoint 2007 and the fix works at all places.